### PR TITLE
Replace QT with Tkinter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pytest
 PyMuPDF==1.24.9 # fitz
 
 # optional
-# PySide6==6.3.2


### PR DESCRIPTION
Change the GUI framework from PySide6 (QT) to Tkinter.

* **requirements.txt**
  - Remove PySide6 dependency.

* **gui.py**
  - Replace PySide6 imports with Tkinter imports.
  - Update `Window` class to inherit from `tk.Tk` instead of `QtWidgets.QDialog`.
  - Replace `QtWidgets.QPushButton` with `tk.Button`.
  - Replace `QtWidgets.QComboBox` with `tk.Entry`.
  - Replace `QtWidgets.QLabel` with `tk.Label`.
  - Update the GUI initialization and layout to use Tkinter components.
  - Implement methods for browsing directories, selecting/unselecting all files, and performing actions using Tkinter.
  - Update the file finding and displaying logic to use Tkinter components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FFengIll/pdf-cut-white?shareId=ae9f363e-0ee5-4a8f-b13a-bc4916f20ed0).